### PR TITLE
Add a rake task to generate a recording script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # develop
+  * [FEATURE] Add rake task to generate Markdown formatted prompt list for recording
+  * [BUGFIX] Fix rake task that validates recording files to handle nested i18n keys
 
 # v1.1.0
   * [FEATURE] Add fallback config option to disable text fallback when audio prompts exist.

--- a/lib/adhearsion-i18n/plugin.rb
+++ b/lib/adhearsion-i18n/plugin.rb
@@ -94,8 +94,9 @@ class AdhearsionI18n::Plugin < Adhearsion::Plugin
 
               # Ignore any prompt that doesn't have a text translation
               next unless mapping['text']
+              audiofile = mapping['audio'] ? mapping['audio'] : "#{key}.wav"
 
-              fh.puts "* `#{key}.wav`: \"#{mapping['text']}\""
+              fh.puts "* `#{audiofile}`: \"#{mapping['text']}\""
               fh.puts
             end
           end

--- a/lib/adhearsion-i18n/plugin.rb
+++ b/lib/adhearsion-i18n/plugin.rb
@@ -71,6 +71,37 @@ class AdhearsionI18n::Plugin < Adhearsion::Plugin
           end
         end
       end
+
+      desc "Generate recording script (Markdown format)"
+      task :generate_script do
+        output_dir = File.join Adhearsion.root, 'doc'
+        File.mkdir output_dir unless File.exist? output_dir
+
+        locale_files = Dir.glob(I18n.load_path)
+        locale_files.each do |locale_file|
+          # We only support YAML for now
+          next unless locale_file =~ /\.ya?ml$/
+
+          prompts = YAML.load File.read(locale_file)
+
+          locale = prompts.keys.first
+          prompts = prompts[locale]
+
+          script_name = File.join output_dir, "#{locale}_script.md"
+          File.open script_name, 'w' do |fh|
+            prompts.each_pair do |key, mapping|
+              logger.trace "Checking i18n key #{key}"
+
+              # Ignore any prompt that doesn't have a text translation
+              next unless mapping['text']
+
+              fh.puts "* `#{key}.wav`: \"#{mapping['text']}\""
+              fh.puts
+            end
+          end
+          File.unlink script_name if File.zero? script_name
+        end
+      end
     end
   end
 end

--- a/lib/adhearsion-i18n/plugin.rb
+++ b/lib/adhearsion-i18n/plugin.rb
@@ -100,7 +100,12 @@ class AdhearsionI18n::Plugin < Adhearsion::Plugin
               fh.puts
             end
           end
-          File.unlink script_name if File.zero? script_name
+          if File.zero? script_name
+            logger.warn "No prompts found, script not created."
+            File.unlink script_name
+          else
+            logger.info "Audio recording script written to #{script_name}"
+          end
         end
       end
 


### PR DESCRIPTION
This rake task will generate a script in Markdown format suitable for sharing with the person who will record the prompts.

Todo:
- [x] Handle nested values (eg. `ivr_section.main_menu`)
- [x] Let the audio filename attribute override the i18n key, if provided
