### PR TITLE
Exposing translator as a library class method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # develop
   * [FEATURE] Add rake task to generate Markdown formatted prompt list for recording
+  * [FEATURE] Expose translator as a library class method (`AdhearsionI18n.t`)
   * [BUGFIX] Fix rake task that validates recording files to handle nested i18n keys
 
 # v1.1.0

--- a/README.md
+++ b/README.md
@@ -61,6 +61,55 @@ class ExampleController < Adhearsion::CallController
 end
 ```
 
+Translations can also be used outside call controllers via `AdhearsionI18n.t`:
+
+en.yml:
+
+```yaml
+en:
+  order_recommendations:
+    new_customer:
+      text: Thank you for calling! Try today's special made just for you.
+      audio: recommendations/new_customer
+    returning_customer:
+      text: Welcome back! You haven't tried today's special made just for you!
+      audio: recommendations/returning_customer
+    loyal_customer:
+      text: You are special!
+      audio: recommendations/loyal_customer
+```
+
+orders_controller.rb:
+
+```Ruby
+class OrdersController < Adhearsion::CallController
+  def run
+    order = Order.new(user)
+    play order.recommendation
+  end
+end
+```
+
+order.rb:
+
+```Ruby
+class Order
+  def initialize(user)
+    @user = user
+  end
+
+  def recommendation
+    if @user.total_calls == 1
+      AdhearsionI18n.t('recommendations/new_customer')
+    elsif (@user.total_calls > 10) || (@user.total_purchases > 500)
+      AdhearsionI18n.t('recommendations/loyal_customer')
+    else
+      AdhearsionI18n.t('recommendations/returning_customer')
+    end
+  end
+end
+```
+
 ## String interpolations
 
 adhearsion-i18n supports string interpolations just as i18n itself does. However there are some guidelines we recommend:

--- a/lib/adhearsion-i18n.rb
+++ b/lib/adhearsion-i18n.rb
@@ -7,4 +7,37 @@
 }.each { |r| require "adhearsion-i18n/#{r}" }
 
 class AdhearsionI18n
+
+  def self.t(key, options = {})
+    this_locale = options[:locale] || locale
+    options = {default: '', locale: locale}.merge(options)
+    prompt = ::I18n.t "#{key}.audio", options
+    text   = ::I18n.t "#{key}.text", options
+
+    if prompt.empty? && text.empty?
+      # Look for a translation key that doesn't follow the Adhearsion-I18n structure
+      text = ::I18n.t key, options
+    end
+
+    unless prompt.empty?
+      prompt = "#{Adhearsion.config.i18n.audio_path}/#{this_locale}/#{prompt}"
+    end
+
+    RubySpeech::SSML.draw language: this_locale do
+      if prompt.empty?
+        string text
+      else
+        if Adhearsion.config.i18n.fallback
+          audio(src: prompt) { string text }
+        else
+          audio(src: prompt)
+        end
+      end
+    end
+  end
+
+  def self.locale
+    I18n.locale || I18n.default_locale
+  end
+
 end

--- a/lib/adhearsion-i18n/call_controller_methods.rb
+++ b/lib/adhearsion-i18n/call_controller_methods.rb
@@ -2,35 +2,11 @@
 
 module AdhearsionI18n::CallControllerMethods
   def t(key, options = {})
-    this_locale = options[:locale] || locale
-    options = {default: '', locale: locale}.merge(options)
-    prompt = ::I18n.t "#{key}.audio", options
-    text   = ::I18n.t "#{key}.text", options
-
-    if prompt.empty? && text.empty?
-      # Look for a translation key that doesn't follow the Adhearsion-I18n structure
-      text = ::I18n.t key, options
-    end
-
-    unless prompt.empty?
-      prompt = "#{Adhearsion.config.i18n.audio_path}/#{this_locale}/#{prompt}"
-    end
-
-    RubySpeech::SSML.draw language: this_locale do
-      if prompt.empty?
-        string text
-      else
-        if Adhearsion.config.i18n.fallback
-          audio(src: prompt) { string text }
-        else
-          audio(src: prompt)
-        end
-      end
-    end
+    AdhearsionI18n.t key, { locale: locale }.merge(options || {})
   end
 
   def locale
-    call[:locale] || I18n.default_locale
+    call[:locale] || AdhearsionI18n.locale
   end
 
   def locale=(l)


### PR DESCRIPTION
This allows the translator method to be used from outside Adhearsion
call controllers (as `AdhearsionI18n.t`).

`CallControllerMethods` now makes use of `AdhearsionI18n.t`.
